### PR TITLE
refactor: use yarn workspace command for build

### DIFF
--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -29,7 +29,7 @@ RUN yarn workspaces focus client
 FROM base AS builder
 COPY --from=install /app /app
 RUN mkdir -p /app/client/public
-RUN yarn build --filter client
+RUN yarn workspace client build
 
 # Stage 3: Production server
 FROM base AS runner

--- a/package.json
+++ b/package.json
@@ -21,13 +21,13 @@
     "build": "turbo run build"
   },
   "dependencies": {
-    "turbo": "^2.5.4",
     "typescript": "5.8.3"
   },
   "devDependencies": {
     "@biomejs/biome": "2.0.6",
     "@types/node": "^20",
-    "globals": "^16.0.0"
+    "globals": "^16.0.0",
+    "turbo": "^2.5.4"
   },
   "engines": {
     "node": ">=22",

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -28,7 +28,7 @@ RUN yarn workspaces focus server
 # Step 3: Build and serve
 FROM base as build
 COPY --from=install /app /app
-RUN yarn build --filter server
+RUN yarn workspace server build
 
 FROM base
 COPY --from=build /app /app


### PR DESCRIPTION
Fixed the docker builds where I expected `turbo` to be installed after focusing on a certain workspace. Now uses workspace build commands instead of the turbo build scripts. Also moved `turbo` to dev deps as it was redundant in deps. 