### PR TITLE
fixed the transperency issue in the mobile nav bar

### DIFF
--- a/client/src/components/navbar/Navbar.tsx
+++ b/client/src/components/navbar/Navbar.tsx
@@ -25,6 +25,18 @@ export const NavigationBar: React.FC<NavigationBarProps> = ({
   const [hasScrolled, setHasScrolled] = useState(false)
 
   useEffect(() => {
+  if (isMobileMenuOpen) {
+    document.body.style.overflow = 'hidden'
+  } else {
+    document.body.style.overflow = ''
+  }
+
+  return () => {
+    document.body.style.overflow = ''
+  }
+}, [isMobileMenuOpen])
+
+  useEffect(() => {
     const handleScroll = () => {
       setHasScrolled(window.scrollY > 0)
     }

--- a/client/src/components/navbar/Navbar.tsx
+++ b/client/src/components/navbar/Navbar.tsx
@@ -25,16 +25,16 @@ export const NavigationBar: React.FC<NavigationBarProps> = ({
   const [hasScrolled, setHasScrolled] = useState(false)
 
   useEffect(() => {
-  if (isMobileMenuOpen) {
-    document.body.style.overflow = 'hidden'
-  } else {
-    document.body.style.overflow = ''
-  }
+    if (isMobileMenuOpen) {
+      document.body.style.overflow = 'hidden'
+    } else {
+      document.body.style.overflow = ''
+    }
 
-  return () => {
-    document.body.style.overflow = ''
-  }
-}, [isMobileMenuOpen])
+    return () => {
+      document.body.style.overflow = ''
+    }
+  }, [isMobileMenuOpen])
 
   useEffect(() => {
     const handleScroll = () => {


### PR DESCRIPTION
# Description

On mobile viewports, the mobile navigation drawer was unexpectedly disappearing when users attempted to scroll, due to browser behavior that collapses fixed elements during background scroll. This wasn't a bug in our drawer logic but rather a UX issue caused by the page remaining scrollable while the drawer was open. To fix this, I added logic to lock the body scroll (document.body.style.overflow = 'hidden') whenever the drawer is active, and restore it when closed. This prevents background scrolling and ensures the drawer remains visible and interactive until explicitly closed, improving the overall mobile navigation experience.

Fixes # (issue)

## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?

- [ ] Manual testing (requires screenshots or videos)


## Checklist before requesting a review

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added thorough tests that prove my fix is effective and that my feature works
- [ ] I have written a storybook for frontend components (if applicable)
- [ ] I've requested a review from another user
